### PR TITLE
Load HostingEnvironment from another assembly

### DIFF
--- a/src/ForEvolve.OperationResults.Shim.Testing/ForEvolve.OperationResults.Shim.Testing.csproj
+++ b/src/ForEvolve.OperationResults.Shim.Testing/ForEvolve.OperationResults.Shim.Testing.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-	<TargetFrameworks>net5.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
-	<ImplicitUsings>enable</ImplicitUsings>
-	<!--<Nullable>enable</Nullable>-->
-	  <LangVersion>latest</LangVersion>
-	<RootNamespace>ForEvolve</RootNamespace>
-  </PropertyGroup>
-	
+	<PropertyGroup>
+		<TargetFrameworks>net5.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<!--<Nullable>enable</Nullable>-->
+		<LangVersion>latest</LangVersion>
+		<RootNamespace>ForEvolve</RootNamespace>
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<Product>ForEvolve OperationResults Shim Testing</Product>
 		<Description>Implement old test helpers. Help migrate projects.</Description>
@@ -16,7 +16,7 @@
 		<RepositoryType>git</RepositoryType>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
-	
+
 	<PropertyGroup>
 		<IsPackable>True</IsPackable>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -49,6 +49,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\ForEvolve.OperationResults.Shim\ForEvolve.OperationResults.Shim.csproj" />
+		<ProjectReference Include="..\ForEvolve.OperationResults.Shim\ForEvolve.OperationResults.Shim.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/ForEvolve.OperationResults.Shim.Testing/ForEvolve.OperationResults.Shim.Testing.csproj
+++ b/src/ForEvolve.OperationResults.Shim.Testing/ForEvolve.OperationResults.Shim.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFrameworks>net5.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<!--<Nullable>enable</Nullable>-->
 		<LangVersion>latest</LangVersion>

--- a/src/ForEvolve.OperationResults.Shim.Testing/ForEvolve.OperationResults.Shim.Testing.csproj
+++ b/src/ForEvolve.OperationResults.Shim.Testing/ForEvolve.OperationResults.Shim.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<!--<Nullable>enable</Nullable>-->
 		<LangVersion>latest</LangVersion>

--- a/src/ForEvolve.OperationResults.Shim.Testing/ForEvolve.OperationResults.Shim.Testing.csproj
+++ b/src/ForEvolve.OperationResults.Shim.Testing/ForEvolve.OperationResults.Shim.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+		<TargetFramework>net5.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<!--<Nullable>enable</Nullable>-->
 		<LangVersion>latest</LangVersion>

--- a/src/ForEvolve.OperationResults.Shim.Testing/OperationResultFactoryFake.cs
+++ b/src/ForEvolve.OperationResults.Shim.Testing/OperationResultFactoryFake.cs
@@ -1,9 +1,9 @@
 ﻿using ForEvolve.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-#if NETSTANDARD2_0
-using Microsoft.AspNetCore.Hosting.Internal;
-#else
+#if NET5_0
 using Microsoft.Extensions.Hosting.Internal;
+#else
+using Microsoft.AspNetCore.Hosting.Internal;
 #endif
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/ForEvolve.OperationResults.Shim.Testing/OperationResultFactoryFake.cs
+++ b/src/ForEvolve.OperationResults.Shim.Testing/OperationResultFactoryFake.cs
@@ -1,6 +1,6 @@
 ﻿using ForEvolve.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Internal;
+using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ForEvolve.AspNetCore

--- a/src/ForEvolve.OperationResults.Shim.Testing/OperationResultFactoryFake.cs
+++ b/src/ForEvolve.OperationResults.Shim.Testing/OperationResultFactoryFake.cs
@@ -1,6 +1,10 @@
 ﻿using ForEvolve.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+#if NETSTANDARD2_0
+using Microsoft.AspNetCore.Hosting.Internal;
+#else
 using Microsoft.Extensions.Hosting.Internal;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ForEvolve.AspNetCore

--- a/src/ForEvolve.OperationResults.Shim.Testing/OperationResultFactoryFake.cs
+++ b/src/ForEvolve.OperationResults.Shim.Testing/OperationResultFactoryFake.cs
@@ -1,11 +1,7 @@
 ﻿using ForEvolve.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-#if NET5_0
-using Microsoft.Extensions.Hosting.Internal;
-#else
-using Microsoft.AspNetCore.Hosting.Internal;
-#endif
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 
 namespace ForEvolve.AspNetCore
 {
@@ -38,6 +34,16 @@ namespace ForEvolve.AspNetCore
         public IOperationResult<TResult> Create<TResult>(TResult result)
         {
             return Instance.Create(result);
+        }
+
+        private class HostingEnvironment : IHostingEnvironment
+        {
+            public string EnvironmentName { get; set; }
+            public string ApplicationName { get; set; }
+            public string WebRootPath { get; set; }
+            public IFileProvider WebRootFileProvider { get; set; }
+            public string ContentRootPath { get; set; }
+            public IFileProvider ContentRootFileProvider { get; set; }
         }
     }
 }

--- a/src/ForEvolve.OperationResults.Shim/ForEvolve.OperationResults.Shim.csproj
+++ b/src/ForEvolve.OperationResults.Shim/ForEvolve.OperationResults.Shim.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
-	  <LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
     <RootNamespace>ForEvolve</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
Load HostingEnvironment from Microsoft.Extensions.Hosting.Internal instead of Microsoft.AspNetCore.Hosting.Internal. This is causing a TypeLoadException in .NET 5.